### PR TITLE
Improve testing of what happens if CamelEntityManagerHandler fails is…

### DIFF
--- a/src/test/java/com/github/fharms/camel/route/BeanWithNoAnnotation.java
+++ b/src/test/java/com/github/fharms/camel/route/BeanWithNoAnnotation.java
@@ -24,6 +24,7 @@ package com.github.fharms.camel.route;
 
 import com.github.fharms.camel.entity.Dog;
 import org.apache.camel.Body;
+import org.apache.camel.Exchange;
 import org.springframework.stereotype.Component;
 
 import javax.persistence.EntityManager;
@@ -40,6 +41,10 @@ public class BeanWithNoAnnotation {
 
     public void noTxAnnotation(@Body Dog dog){
         em.persist(dog);
+    }
+
+    public void noTxAnnotationWithExchange(Exchange exchange) {
+        em.persist(exchange.getIn().getBody(Dog.class));
     }
 
 

--- a/src/test/java/com/github/fharms/camel/route/CamelEntityManagerTestRoute.java
+++ b/src/test/java/com/github/fharms/camel/route/CamelEntityManagerTestRoute.java
@@ -105,6 +105,11 @@ class CamelEntityManagerTestRoute extends RouteBuilder {
         from(CamelEntityManagerTestRoutes.DIRECT_NO_TX_ANNOTATION_TEST.uri())
                 .routeId(CamelEntityManagerTestRoutes.DIRECT_NO_TX_ANNOTATION_TEST.id())
                 .bean(BeanWithNoAnnotation.class, "noTxAnnotation");
+
+        from(CamelEntityManagerTestRoutes.MANUEL_POLL_JPA_NO_TX_ANNOTATION_WITH_EXCHANGE_TEST.uri())
+                .routeId(CamelEntityManagerTestRoutes.MANUEL_POLL_JPA_NO_TX_ANNOTATION_WITH_EXCHANGE_TEST.id())
+                .pollEnrich(CamelEntityManagerTestRoutes.DIRECT_JPA_NO_TX_ANNOTATION_WITH_EXCHANGE_TEST.uri(),0)
+                .bean(BeanWithNoAnnotation.class, "noTxAnnotationWithExchange");
     }
 
     /**

--- a/src/test/java/com/github/fharms/camel/route/CamelEntityManagerTestRoutes.java
+++ b/src/test/java/com/github/fharms/camel/route/CamelEntityManagerTestRoutes.java
@@ -42,8 +42,9 @@ public enum CamelEntityManagerTestRoutes {
     DIRECT_INJECT_PERSISTENCE_CONTEXT_TEST("direct:injectPersistenceContext", "injectPersistenceContext"),
     MANUEL_POLL_JPA_CONSUMER_IGNORE_TEST("direct:manuelPollingConsumerIgnoreTest","manuelPollingConsumerIgnoreTest"),
     DIRECT_IGNORE_CAMEL_EM_TEST("jpa:com.github.fharms.camel.entity.Dog", "ignoreCamelEntityManager"),
-    DIRECT_NO_TX_ANNOTATION_TEST("direct:noTxTest", "noTxTest");
-
+    DIRECT_NO_TX_ANNOTATION_TEST("direct:noTxTest", "noTxTest"),
+    MANUEL_POLL_JPA_NO_TX_ANNOTATION_WITH_EXCHANGE_TEST("direct:noTxExchangePollingConsumerTest", "noTxExchangePollingConsumerTest"),
+    DIRECT_JPA_NO_TX_ANNOTATION_WITH_EXCHANGE_TEST("jpa:com.github.fharms.camel.entity.Dog","directJpaConsumerNoTx");
     private final String routeUri;
     private final String routeId;
 


### PR DESCRIPTION
… the internal value in it's ThreadLocal removed